### PR TITLE
have Rust + bump Python versions (Fixes #20)

### DIFF
--- a/Dockerfile_alpine
+++ b/Dockerfile_alpine
@@ -2,11 +2,12 @@
 ############################
 # Pynv but no environments #
 ############################
-ARG IMAGE_VERSION=3.12
+ARG IMAGE_VERSION=3.13
 FROM alpine:$IMAGE_VERSION as pyenv_clean
 ENV CFLAGS='-O2'
 
 RUN apk add --no-cache \
+        cargo \
         curl \
         git \
         bash \
@@ -32,7 +33,7 @@ ENTRYPOINT ["/bin/bash", "-lc"]
 # Prebuild given versions #
 ###########################
 FROM pyenv_clean as pyenv_prebuild
-ARG BUILD_PYTHON_VERSIONS="3.9.0 3.8.6 3.7.9 3.6.12"
+ARG BUILD_PYTHON_VERSIONS="3.9.1 3.8.7 3.7.9 3.6.12"
 
 RUN for pyver in $BUILD_PYTHON_VERSIONS; do pyenv install $pyver; done \
     && pyenv global $BUILD_PYTHON_VERSIONS

--- a/Dockerfile_debian
+++ b/Dockerfile_debian
@@ -19,6 +19,11 @@ RUN apt-get update \
        openssh-client \
        libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget \
        libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+    # No recent enough Rust in Debian packages (2021-02-11)
+    && curl -o /tmp/rustup.sh --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    && chmod +x /tmp/rustup.sh \
+    && /tmp/rustup.sh -y \
+    && echo 'source /root/.cargo/env' >> /root/.profile \
     # githublab ssh
     && mkdir -p -m 0700 ~/.ssh && ssh-keyscan gitlab.com github.com | sort > ~/.ssh/known_hosts \
     # install pyenv
@@ -35,7 +40,7 @@ ENTRYPOINT ["/bin/bash", "-lc"]
 # Prebuild given versions #
 ###########################
 FROM pyenv_clean as pyenv_prebuild
-ARG BUILD_PYTHON_VERSIONS="3.9.0 3.8.6 3.7.9 3.6.12"
+ARG BUILD_PYTHON_VERSIONS="3.9.1 3.8.7 3.7.9 3.6.12"
 
 RUN for pyver in $BUILD_PYTHON_VERSIONS; do pyenv install $pyver; done \
     && pyenv global $BUILD_PYTHON_VERSIONS

--- a/Dockerfile_ubuntu
+++ b/Dockerfile_ubuntu
@@ -10,6 +10,7 @@ ENV CFLAGS='-O2' \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bash \
+       cargo \
        curl \
        ca-certificates \
        git-core \
@@ -35,7 +36,7 @@ ENTRYPOINT ["/bin/bash", "-lc"]
 # Prebuild given versions #
 ###########################
 FROM pyenv_clean as pyenv_prebuild
-ARG BUILD_PYTHON_VERSIONS="3.9.0 3.8.6 3.7.9 3.6.12"
+ARG BUILD_PYTHON_VERSIONS="3.9.1 3.8.7 3.7.9 3.6.12"
 
 RUN for pyver in $BUILD_PYTHON_VERSIONS; do pyenv install $pyver; done \
     && pyenv global $BUILD_PYTHON_VERSIONS

--- a/create_builds.py
+++ b/create_builds.py
@@ -5,7 +5,7 @@ import sys
 
 PLATFORMS = ["linux/amd64", "linux/arm64"]
 TARGETS = ["pyenv", "tox-base"]
-VARIANTS = ["alpine-3.12", "debian-buster", "ubuntu-focal"]
+VARIANTS = ["alpine-3.13", "debian-buster", "ubuntu-focal"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These haven't been built yet, that takes too many hours so needs to happen in EC2. Iirc used one of these the last time because there are long stretches during the build when just a single core is blasting at full: https://aws.amazon.com/ec2/instance-types/z1d/